### PR TITLE
fwdSetup: new --backup option for additional paths to save/restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,25 @@ Below is the list of global variables.
 Asserts environment and starts firewalld. Configuration cleanup is attempted
 and default state is verified.
 
-    fwdSetup [-n|--no-start]
+    fwdSetup [-n|--no-start] [--backup PATH]
 
 - -n|--no-start
 
     Do not start service after setup.
+
+- --backup _PATH_
+
+    Additional path to save and restore as part of setup and cleanup.
+    Passed to `rlFileBackup`. Can be supplied multiple times.
+
+    No matter if this option is specified, the following paths are
+    always backed up:
+
+    `/etc/firewalld/`
+
+    `/etc/sysconfig/firewalld`
+
+    `/etc/sysconfig/network-scripts/`
 
 ## fwdCleanup
 

--- a/main/runtest.sh
+++ b/main/runtest.sh
@@ -130,6 +130,27 @@ rlJournalStart
             rlAssertNotDiffer backend.out /dev/null
             rlRun "fwdCleanup"
         rlPhaseEnd
+
+        rlPhaseStartTest "fwdSetup --backup option"
+            rlLogInfo "Single --backup"
+            rlRun "fwdSetup --backup /usr/lib/firewalld/"
+            rlRun "added_file=$(mktemp /usr/lib/firewalld/addedXXXXXX)"
+            rlAssertExists "$added_file"
+            rlRun "fwdCleanup"
+            rlAssertNotExists "$added_file"
+
+            rlLogInfo "Multiple --backup and -n together"
+            rlRun "fwdSetup --backup /usr/lib/firewalld/services/ -n \
+                            --backup /usr/lib/firewalld/zones/"
+            rlRun "firewall-cmd --state" 252 "firewalld is not runnig"
+            rlRun "added_service_file=$(mktemp /usr/lib/firewalld/services/XXXXXX)"
+            rlRun "added_zone_file=$(mktemp /usr/lib/firewalld/zones/XXXXXX)"
+            rlAssertExists "$added_service_file"
+            rlAssertExists "$added_zone_file"
+            rlRun "fwdCleanup"
+            rlAssertNotExists "$added_service_file"
+            rlAssertNotExists "$added_zone_file"
+        rlPhaseEnd
     fi
 
     rlPhaseStartCleanup


### PR DESCRIPTION
Sometimes we need to back up additional paths for a specific test.
Doing that manually can lead to timing issues or clashes with existing
fwd{Setup,Cleanup} functionality.

Teach fwdSetup to save and restore additional paths (specified using
the --backup option) together with the default paths.